### PR TITLE
feat: add avante ai assistant integration

### DIFF
--- a/lua/beastvim/plugins/aisync/avante.lua
+++ b/lua/beastvim/plugins/aisync/avante.lua
@@ -1,0 +1,20 @@
+--[[
+  Unleash seamless collaboration between AI and coding
+  Effortlessly boost efficiency with plugins that adapt to your needs,
+  creating a streamlined and innovative development experience.
+                                        -- Aisync --
+]]
+
+return {
+  {
+    "yetone/avante.nvim",
+    event = "VeryLazy",
+    config = true,
+    dependencies = {
+      "nvim-tree/nvim-web-devicons",
+      "nvim-lua/plenary.nvim",
+      "MunifTanjim/nui.nvim",
+      "stevearc/dressing.nvim",
+    },
+  },
+}

--- a/lua/beastvim/plugins/aisync/init.lua
+++ b/lua/beastvim/plugins/aisync/init.lua
@@ -22,6 +22,7 @@ local cond = function()
 end
 
 return {
+  { import = "beastvim.plugins.aisync.avante", cond = cond },
   { import = "beastvim.plugins.aisync.copilot", cond = cond },
   { import = "beastvim.plugins.aisync.codeium", enabled = false },
   { import = "beastvim.plugins.aisync.supermaven", cond = cond },


### PR DESCRIPTION
## Summary
- add the Avante AI assistant plugin specification with its required dependencies
- register the Avante module in the aisync plugin imports so it loads alongside other AI helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43d26dc84832cad9c01be86941921