### PR TITLE
feat: add Avante AI assistant configuration

### DIFF
--- a/lua/beastvim/plugins/aisync/avante.lua
+++ b/lua/beastvim/plugins/aisync/avante.lua
@@ -1,0 +1,50 @@
+return {
+  {
+    "yetone/avante.nvim",
+    event = "VeryLazy",
+    cmd = {
+      "AvanteChat",
+      "AvanteToggle",
+      "AvanteAsk",
+    },
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "MunifTanjim/nui.nvim",
+      "stevearc/dressing.nvim",
+    },
+    keys = {
+      { "<leader>aa", "<cmd>AvanteChat<cr>", desc = "Apri Avante" },
+      { "<leader>at", "<cmd>AvanteToggle<cr>", desc = "Mostra/Nascondi Avante" },
+    },
+    opts = function()
+      local opts = {
+        provider = vim.env.BEASTVIM_AVANTE_PROVIDER or "claude",
+        claude = {
+          api_key = vim.env.ANTHROPIC_API_KEY,
+          model = vim.env.BEASTVIM_AVANTE_CLAUDE_MODEL or "claude-3-5-sonnet-20240620",
+        },
+        openai = {
+          api_key = vim.env.OPENAI_API_KEY,
+          model = vim.env.BEASTVIM_AVANTE_OPENAI_MODEL or "gpt-4o-mini",
+        },
+        cursor = {
+          api_key = vim.env.CURSOR_API_KEY,
+        },
+        windows = {
+          sidebar = {
+            position = "right",
+            width = 0.33,
+          },
+          input = {
+            border = "rounded",
+          },
+        },
+      }
+
+      return opts
+    end,
+    config = function(_, opts)
+      require("avante").setup(opts)
+    end,
+  },
+}

--- a/lua/beastvim/plugins/aisync/init.lua
+++ b/lua/beastvim/plugins/aisync/init.lua
@@ -25,4 +25,5 @@ return {
   { import = "beastvim.plugins.aisync.copilot", cond = cond },
   { import = "beastvim.plugins.aisync.codeium", enabled = false },
   { import = "beastvim.plugins.aisync.supermaven", cond = cond },
+  { import = "beastvim.plugins.aisync.avante", cond = cond },
 }

--- a/lua/beastvim/plugins/treesitter.lua
+++ b/lua/beastvim/plugins/treesitter.lua
@@ -22,6 +22,7 @@ return {
       ensure_installed = {
         "bash",
         "c",
+        "cpp",
         "diff",
         "html",
         "javascript",


### PR DESCRIPTION
## Summary
- add Avante AI assistant plugin with default provider configuration and key bindings
- ensure the aisync module loads the Avante integration
- extend Treesitter installation to cover the cpp parser alongside C support

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e43f48fab0832c96e313a480cb6804